### PR TITLE
fixed issue #6

### DIFF
--- a/vendor/caseyamcl/toc/src/MarkupFixer.php
+++ b/vendor/caseyamcl/toc/src/MarkupFixer.php
@@ -61,7 +61,7 @@ class MarkupFixer
      * @return string Markup with added IDs
      * @throws RuntimeException
      */
-    public function fix($markup, $topLevel = 1, $depth = 6)
+    public function fix($markup, $topLevel, $depth)
     {
         if ( ! $this->isFullHtmlDocument($markup)) {
             $partialID = 'toc_generator_' . mt_rand(1000, 4000);


### PR DESCRIPTION
The `$start` and `$end` variables got reset when calling `MarkupFixer.fix`. 