### PR TITLE
Expose slugify options to user

### DIFF
--- a/classes/UniqueSlugify.php
+++ b/classes/UniqueSlugify.php
@@ -53,8 +53,8 @@ class UniqueSlugify implements SlugifyInterface
         $maxlen = $options['maxlen'] ?? null;
         $prefix = $options['prefix'] ?? null;
 
-        if (is_int($maxlen) && strlen($slugged) > $maxlen) {
-            $slugged = substr($slugged, 0, $maxlen);
+        if (is_int($maxlen) && mb_strlen($slugged) > $maxlen) {
+            $slugged = mb_substr($slugged, 0, $maxlen);
         }
 
         if (isset($prefix)) {

--- a/page-toc.php
+++ b/page-toc.php
@@ -94,7 +94,7 @@ class PageTOCPlugin extends Plugin
         if ($active || $shortcode_exists) {
             $this->registerTwigFunctions();
             $markup_fixer = new MarkupFixer();
-            $content = $markup_fixer->fix($content, $this->getAnchorOptions($page));
+            $content = $markup_fixer->fix($content, array_merge($this->getAnchorOptions($page), $this->getSlugifyOptions($page)));
             $page->setRawContent($content);
         }
 
@@ -149,7 +149,7 @@ class PageTOCPlugin extends Plugin
         }));
 
         $twig->addFunction(new TwigFunction('add_anchors', function ($markup, $start = null, $depth = null) {
-            $options = $this->getAnchorOptions(null, $start, $depth);
+            $options = array_merge($this->getAnchorOptions(null, $start, $depth), $this->getSlugifyOptions(null));
             return $this->fixer->fix($markup, $options);
         }, ['is_safe' => ['html']]));
 
@@ -213,6 +213,28 @@ class PageTOCPlugin extends Plugin
             'maxlen'    => (int) ($this->configVar('anchors.slug_maxlen', $page,null)),
             'prefix'    => $this->configVar('anchors.slug_prefix', $page,null),
         ];
+    }
+
+    protected function getSlugifyOptions(PageInterface $page = null): array
+    {
+        $page = $page ?? $this->grav['page'];
+        $slugify_options = [];
+        foreach ([
+            'regexp',
+            'separator',
+            'lowercase',
+            'lowercase_after_regexp',
+            'trim',
+            'strip_tags',
+            'rulesets'
+            ] as $option_name) {
+                $option_value = $this->configVar('slugify.' . $option_name, $page,null);
+                if (!is_null($option_value)) {
+                    $slugify_options[$option_name] = $option_value;
+                }
+            }
+
+        return $slugify_options;
     }
 
     public static function configVar($var, $page = null, $default = null)


### PR DESCRIPTION
I have a problem using this plugin since my site is primarily written in an alphabet for which "slugify" has no ruleset. This results in all slugs being output as an empty string. One solution would be to try to get a ruleset added to slugify for my language. Strictly speaking, however, this isn't necessary, as slugs don't _have_ to be in ASCII. It would be sufficient to modify the regex expression that determines which characters are thrown away when creating the slug. This is allowed through the slugify option "regexp". This option and others are also exposed to the user in PHP TOC Generator, on which this plugin is based ([you can even inject your own sluggifier](https://github.com/caseyamcl/toc/commit/1bcb989a7765bef38eb2e68a25c43414395d0dce)). However, as far as I can tell, the user of this Grav plugin has no ability to modify the slugify parameters without making changes to the plugin itself. 

In this commit I attempted to allow for this possibilty in the least intrunsive way possible, by taking advantage of the options parameter passed to the `fix` method of `MarkupFixer`. The user can make changes to any of the slugify parameters by modifying page-toc.yaml. If this is not done, the `fix` method should receive the exact same array as before this commit. I also did this so as not to have to hardcode any defaults of the slugify options. 

I didn't make any changes to blueprints.yaml or the deafult page-toc.yaml, in case you don't want to make the possibility of modifying the slugify options to be too obvious to the user. (As I said I was going for minimal intrusiveness.)

Since the possibility of changing the regexp option allows (as in my case) for non-ASCII slugs, I also replaced a couple string functions with their mb_ versions. 

I've tested this, changing around different slugify options on my site, and as far as I can tell it works correctly.