### PR TITLE
fix: alignment of anchors

### DIFF
--- a/assets/page-toc-anchors.css
+++ b/assets/page-toc-anchors.css
@@ -5,12 +5,11 @@
 }
 
 .toc-anchor.after {
-    margin-left: 5px;
+    margin-left: .25em;
 }
 
 .toc-anchor.before {
-    margin-left: -22px;
-    padding-right: 8px;
+    margin-left: -.75em;
 }
 
 .toc-anchor:after {

--- a/languages.yaml
+++ b/languages.yaml
@@ -1,3 +1,6 @@
+ru:
+  PLUGIN_PAGE_TOC:
+    TABLE_OF_CONTENTS: Содержание
 de:
   PLUGIN_PAGE_TOC:
     TABLE_OF_CONTENTS: Inhaltsverzeichnis


### PR DESCRIPTION
This PR fixes the alignment of anchors generated more naturally using relative measurement instead of absolute. Please see comparison below. The issue with pixel is that it doesn't adapt to the font size. With em, it adapts to the font size of the heading.

|  | Before | After |
|--------|--------|--------|
| Left align | ![toc-headings-left-before](https://github.com/trilbymedia/grav-plugin-page-toc/assets/73113302/d1b2b222-755a-4660-ae49-a4d5f7c977b4) | ![toc-headings-left-after](https://github.com/trilbymedia/grav-plugin-page-toc/assets/73113302/c94cd908-c4f8-49c0-9f4d-48c8a4f78a4c) |
| Right align | ![toc-headings-right-before](https://github.com/trilbymedia/grav-plugin-page-toc/assets/73113302/f0f36a6c-3387-43a0-b9e9-eb9b2634a125) | ![toc-headings-right-after](https://github.com/trilbymedia/grav-plugin-page-toc/assets/73113302/3f588608-ccec-4b12-8e67-544e9d287ca5) |





