### PR TITLE
Expose Slugify options to user

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -184,3 +184,77 @@ form:
           type: text
           label: PLUGIN_PAGE_TOC.SLUG_PREFIX
           help: PLUGIN_PAGE_TOC.SLUG_PREFIX_HELP
+
+    slugify_section:
+      type: section
+      title: Slugify
+      underline: true
+
+      fields:
+        slugify.regexp:
+          type: text
+          label: Regexp
+          help: Regular expression used by slugify to replace separators.
+          placeholder: '/([^A-Za-z0-9]|-)+/'
+        slugify.separator:
+          type: text
+          label: Separator
+          help: String used to separate words in generated slugs.
+          placeholder: '-'
+          size: x-small
+        slugify.lowercase:
+          type: toggle
+          label: Lowercase
+          highlight: 1
+          default: 1
+          options:
+            1: Enabled
+            0: Disabled
+          validate:
+            type: bool
+        slugify.lowercase_after_regexp:
+          type: toggle
+          label: Lowercase After Regexp
+          highlight: 0
+          default: 0
+          options:
+            1: Enabled
+            0: Disabled
+          validate:
+            type: bool
+        slugify.trim:
+          type: toggle
+          label: Trim Separator
+          highlight: 1
+          default: 1
+          options:
+            1: Enabled
+            0: Disabled
+          validate:
+            type: bool
+        slugify.strip_tags:
+          type: toggle
+          label: Strip Tags
+          highlight: 0
+          default: 0
+          options:
+            1: Enabled
+            0: Disabled
+          validate:
+            type: bool
+        slugify.custom_rulesets:
+          type: toggle
+          label: Custom Rulesets
+          help: Enable to override Slugify default rulesets. Disabled keeps Slugify defaults.
+          highlight: 0
+          default: 0
+          options:
+            1: Enabled
+            0: Disabled
+          validate:
+            type: bool
+        slugify.rulesets:
+          type: array
+          label: Rulesets
+          help: Ordered list of transliteration rulesets (for example default, turkish). Used only when Custom Rulesets is enabled; an empty list disables transliteration rules.
+          value_only: true

--- a/classes/MarkupFixer.php
+++ b/classes/MarkupFixer.php
@@ -44,7 +44,7 @@ class MarkupFixer
         $start = (int) $options['start'] ?? 1;
         $depth = (int) $options['depth'] ?? 6;
         $domDocument = $this->getHTMLParser($markup);
-        $slugger = new UniqueSlugify();
+        $slugger = new UniqueSlugify($options);
 
         /** @var DOMElement $node */
         foreach ($this->traverseHeaderTags($domDocument, $start, $depth) as $node) {

--- a/classes/UniqueSlugify.php
+++ b/classes/UniqueSlugify.php
@@ -26,17 +26,34 @@ class UniqueSlugify implements SlugifyInterface
     protected $slugify;
     protected $used;
 
-    protected $options;
-
     /**
      * Constructor
      *
-     * @param SlugifyInterface|null $slugify
+     * @param array<string,mixed> $options
      */
-    public function __construct()
+    public function __construct(array $options = [])
     {
         $this->used = array();
-        $this->slugify = new Slugify();
+        $this->slugify = new Slugify($this->getSlugifyConstructorOptions($options));
+    }
+
+    /**
+     * Only pass options recognized by cocur/slugify constructor.
+     *
+     * @param array<string,mixed> $options
+     * @return array<string,mixed>
+     */
+    protected function getSlugifyConstructorOptions(array $options): array
+    {
+        return array_intersect_key($options, array_flip([
+            'regexp',
+            'separator',
+            'lowercase',
+            'lowercase_after_regexp',
+            'trim',
+            'strip_tags',
+            'rulesets',
+        ]));
     }
 
     /**
@@ -53,8 +70,8 @@ class UniqueSlugify implements SlugifyInterface
         $maxlen = $options['maxlen'] ?? null;
         $prefix = $options['prefix'] ?? null;
 
-        if (is_int($maxlen) && strlen($slugged) > $maxlen) {
-            $slugged = substr($slugged, 0, $maxlen);
+        if (is_int($maxlen) && mb_strlen($slugged) > $maxlen) {
+            $slugged = mb_substr($slugged, 0, $maxlen);
         }
 
         if (isset($prefix)) {

--- a/classes/shortcodes/AnchorShortcode.php
+++ b/classes/shortcodes/AnchorShortcode.php
@@ -8,6 +8,28 @@ use Thunder\Shortcode\Shortcode\ProcessedShortcode;
 
 class AnchorShortcode extends Shortcode
 {
+  /**
+   * @return array<string,mixed>
+   */
+  protected function getSlugifyOptions(): array
+  {
+    $options = [];
+    $customRulesets = (bool) PageTOCPlugin::configVar('slugify.custom_rulesets', null, false);
+
+    foreach (['regexp', 'separator', 'lowercase', 'lowercase_after_regexp', 'trim', 'strip_tags'] as $key) {
+      $value = PageTOCPlugin::configVar('slugify.' . $key);
+      if ($value !== null) {
+        $options[$key] = $value;
+      }
+    }
+
+    if ($customRulesets) {
+      $options['rulesets'] = PageTOCPlugin::configVar('slugify.rulesets', null, []);
+    }
+
+    return $options;
+  }
+
   public function init()
   {
     $this->shortcode->getRawHandlers()->add('anchor', function(ProcessedShortcode $sc) {
@@ -18,11 +40,12 @@ class AnchorShortcode extends Shortcode
       $class = $this->cleanParam($sc->getParameter('class', 'inline-anchor'));
       $aria = PageTOCPlugin::configVar('anchors.aria');
       $content = $sc->getContent();
+      $slugifyOptions = $this->getSlugifyOptions();
 
-      $slugger = new UniqueSlugify();
+      $slugger = new UniqueSlugify($slugifyOptions);
 
       if (is_null($id)) {
-          $id = $slugger->slugify(strip_tags($content));
+          $id = $slugger->slugify(strip_tags($content), $slugifyOptions);
       }
 
       if (isset($prefix)) {

--- a/page-toc.php
+++ b/page-toc.php
@@ -97,7 +97,7 @@ class PageTOCPlugin extends Plugin
         if ($active || $is_template_activated || $shortcode_exists) {
             $this->registerTwigFunctions();
             $markup_fixer = new MarkupFixer();
-            $content = $markup_fixer->fix($content, $this->getAnchorOptions($page));
+            $content = $markup_fixer->fix($content, array_merge($this->getAnchorOptions($page), $this->getSlugifyOptions($page)));
             $page->setRawContent($content);
         }
 
@@ -152,7 +152,7 @@ class PageTOCPlugin extends Plugin
         }));
 
         $twig->addFunction(new TwigFunction('add_anchors', function ($markup, $start = null, $depth = null) {
-            $options = $this->getAnchorOptions(null, $start, $depth);
+            $options = array_merge($this->getAnchorOptions(null, $start, $depth), $this->getSlugifyOptions(null));
             return $this->fixer->fix($markup, $options);
         }, ['is_safe' => ['html']]));
 
@@ -217,6 +217,33 @@ class PageTOCPlugin extends Plugin
             'maxlen'    => (int) ($this->configVar('anchors.slug_maxlen', $page,null)),
             'prefix'    => $this->configVar('anchors.slug_prefix', $page,null),
         ];
+    }
+
+    protected function getSlugifyOptions(PageInterface $page = null): array
+    {
+        $page = $page ?? $this->grav['page'];
+        $slugify_options = [];
+        $custom_rulesets = (bool) $this->configVar('slugify.custom_rulesets', $page, false);
+
+        foreach ([
+            'regexp',
+            'separator',
+            'lowercase',
+            'lowercase_after_regexp',
+            'trim',
+            'strip_tags'
+            ] as $option_name) {
+                $option_value = $this->configVar('slugify.' . $option_name, $page,null);
+                if (!is_null($option_value)) {
+                    $slugify_options[$option_name] = $option_value;
+                }
+            }
+
+        if ($custom_rulesets) {
+            $slugify_options['rulesets'] = $this->configVar('slugify.rulesets', $page, []);
+        }
+
+        return $slugify_options;
     }
 
     public static function configVar($var, $page = null, $default = null)

--- a/page-toc.yaml
+++ b/page-toc.yaml
@@ -16,3 +16,33 @@ anchors:                    # Anchor configuration
   copy_to_clipboard: false  # Copy to clipboard functionality
   slug_maxlen: 25           # Max length of slugs used for anchors
   slug_prefix:              # A prefix used in front of generated slugs
+slugify:
+  custom_rulesets: false    # Use Slugify defaults unless explicitly overriding rulesets
+  regexp: '/([^A-Za-z0-9]|-)+/'
+  separator: '-'
+  lowercase: true
+  lowercase_after_regexp: false
+  trim: true
+  strip_tags: false
+  rulesets:                 # Used only when custom_rulesets is true
+    - default
+    - yiddish
+    - armenian
+    - azerbaijani
+    - burmese
+    - hindi
+    - georgian
+    - norwegian
+    - vietnamese
+    - ukrainian
+    - latvian
+    - finnish
+    - greek
+    - czech
+    - arabic
+    - slovak
+    - turkish
+    - polish
+    - german
+    - russian
+    - romanian


### PR DESCRIPTION
This is an expanded version of #34, which didn't support changes to "rulesets", which I needed for my own site. 
I also decided to go all out and add the options to the admin interface, and default values to the config YAML to make it easier for the user to find the settings. 
It's also based on the latest 4.0 version of the plugin. I tested it in Grav/admin 2.0. 